### PR TITLE
Reworded sign-up confirmation message

### DIFF
--- a/site/src/components/SignupForm/index.js
+++ b/site/src/components/SignupForm/index.js
@@ -261,7 +261,11 @@ The Meshery Playground is connected to live Kubernetes cluster(s) and allows use
             on the status of your access via the email address you provided during registration.
           </p>
           <p>
-            If you have any questions in the meantime, please send an email to{' '}
+            If you have any questions in the meantime, feel free to share them in our
+            <a href='https://slack.meshery.io/'>Slack community</a>
+            or our
+            <a href='https://discuss.layer5.io/'>discussion forum</a>.
+            You could also send an email to{' '}
             <a href='mailto:learn@meshery.io'>learn@meshery.io</a>.
           </p>
           <h3 className='white'>

--- a/site/src/components/SignupForm/index.js
+++ b/site/src/components/SignupForm/index.js
@@ -257,9 +257,8 @@ The Meshery Playground is connected to live Kubernetes cluster(s) and allows use
         <div className='thankyou-box'>
           <h2>Thank you for your interest in Meshery Playground early access program!</h2>
           <p>
-            You are now signed up for the Meshery Playground early access program and your position
-            on the waiting list is confirmed. Please wait patiently for a response from the Meshery
-            team.
+            Your sign-up is confirmed, and you are now on the waiting list. We will notify you
+            on the status of your access via the email address you provided during registration.
           </p>
           <p>
             If you have any questions in the meantime, please send an email to{' '}


### PR DESCRIPTION
**Notes for Reviewers**
Reworded the "thank you" message that pops up after users sign up for early access to Meshery Playground. The new one points out the channel through which users will be notified of the status of their access request.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
