### PR TITLE
fix:slack button url

### DIFF
--- a/site/src/App.js
+++ b/site/src/App.js
@@ -100,7 +100,7 @@ const App = () => {
             <div>
               <h1>Join the community!</h1>
               <p>Engage in the Meshery community by joining us on Slack</p>
-              <Button href="https://slack.meshery.io/" >Join Our Open Source Community</Button>
+              <Button url="https://slack.meshery.io/" >Join Our Open Source Community</Button>
             </div>
           </section>
           <section>

--- a/site/src/App.style.js
+++ b/site/src/App.style.js
@@ -265,21 +265,6 @@ export const Main = styled.main`
 
   .join-community {
     text-align: center;
-    a {
-      display: block;
-      background: #ebc017;
-      color: ${({ theme }) => theme.btn};
-      width: 14rem;
-      padding: 1rem;
-      margin: auto;
-      border-radius: 0.5rem;
-      transition: 0.2s ease-in-out;
-      &:hover {
-        background-color: rgba(255, 208, 25, 1);
-        box-shadow: 0px 0px 12px #ebc017;
-        color: #fff;
-      }
-    }
   }
 section.playground-btn {
   margin-top: 4rem;


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes opening intended slack URL on button click.
- Replaced the button href prop with url prop 
- Removed the styling of `<a>` tag inside `join-community` section as
   - it over-rid the button style by adding a yellowish background to the button which should have teal background color only
   - No other `<a>` tag present inside the section, hence I think styling it was unnecessary.
   - To maintain consistency, `<Button/>` component should be used along with `url` prop and the styling should be applied on the button instead of `<a>` tag.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
