### PR TITLE
fix: navbar stays above page content by increasing z-index (#271)

### DIFF
--- a/site/src/components/Navigation/Navigation.styles.js
+++ b/site/src/components/Navigation/Navigation.styles.js
@@ -4,7 +4,7 @@ export const Header = styled.header`
   position: sticky;
   top: 0;
   background: #fff;
-  z-index: 9999;
+  z-index: ${({ theme }) => theme.zIndex.navbar};
 
 
   .dropdown_btn {

--- a/site/src/components/Navigation/Navigation.styles.js
+++ b/site/src/components/Navigation/Navigation.styles.js
@@ -4,7 +4,8 @@ export const Header = styled.header`
   position: sticky;
   top: 0;
   background: #fff;
-  z-index: 2;
+  z-index: 9999;
+
 
   .dropdown_btn {
     display: none;

--- a/site/src/index.style.js
+++ b/site/src/index.style.js
@@ -155,6 +155,9 @@ export const lightTheme = {
   toggleBorder: '#FFF',
   background: '#363537',
   btn: '#FFF',
+  zIndex: {
+    navbar: 1000,
+  },
 }
 export const darkTheme = {
   body: 'rgb(18, 18, 18)',
@@ -162,4 +165,7 @@ export const darkTheme = {
   toggleBorder: '#6B8096',
   background: '#999',
   btn: '#1E2117',
+  zIndex: {
+    navbar: 1000,
+  },
 }


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #271.

### What was happening
The Tutorial and Learn More buttons were appearing above the Navigation bar while scrolling.

### Fix
Added a high z-index (9999) to the NavigationContainer component in Navigation.styles.js, ensuring the navbar always stays above all content.




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ x] Yes, I signed my commits.
 
<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
