### PR TITLE
Prevent duplicate categories in release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
+no-duplicate-categories: true 
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #273  by preventing duplicate pull request entries in the draft release notes when a PR has multiple labels that match different categories.

It adds `no-duplicate-categories: true` to `.github/release-drafter.yml`, ensuring each PR appears only once, in the first matching category.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
