### PR TITLE
fix(faq): prevent modal width expansion when accordion opens

### DIFF
--- a/site/src/components/Faq/faqSection.style.js
+++ b/site/src/components/Faq/faqSection.style.js
@@ -4,6 +4,9 @@ const FaqSectionWrapper = styled.section`
   margin: 0.5rem auto;
   position: relative;
   overflow: scroll;
+  width: 100%;
+  max-width: 900px; 
+  box-sizing: border-box;
   &::-webkit-scrollbar {
     display: none;
   }
@@ -40,6 +43,7 @@ const FaqSectionWrapper = styled.section`
         font-size: 18px;
         position: relative;
         color: #ffffff;
+        padding-right: 3rem;
       }
       > div {
         &:focus {


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #281 

- Fixed modal width expansion when FAQ accordion opens.
- Ensured consistent container width.
- Prevented layout shift caused by overflow.


**Signed commits**
- [x] Yes, I signed my commits.


https://github.com/user-attachments/assets/4c5f7c92-8bd5-47a2-91f9-b8b8c2dfd47f

