### PR TITLE
Fix broken discussion forum links (Footer + Banner) #283

### DIFF
--- a/site/src/components/Discuss-Callout/index.js
+++ b/site/src/components/Discuss-Callout/index.js
@@ -9,7 +9,7 @@ const DiscussCallout = () => {
       <div className="explain">
         <div className="cards">
           <div className="card">
-            <a href="http://discuss.meshery.io/" target="_blank" rel="noreferrer">
+            <a href="https://discuss.layer5.io/" target="_blank" rel="noreferrer">
               <div className="parentcard">
                 <div className="section-title">
                   <h2>Join the Conversation</h2>

--- a/site/src/components/Discuss-Callout/index.js
+++ b/site/src/components/Discuss-Callout/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import DiscussWrapper from "./discuss.style";
-
+import { DISCUSS_FORUM_URL } from "../../constants/links";
 import Discuss from "../../assets/images/meshery-learn-logo-white.png";
 
 const DiscussCallout = () => {
@@ -9,7 +9,7 @@ const DiscussCallout = () => {
       <div className="explain">
         <div className="cards">
           <div className="card">
-            <a href="https://discuss.layer5.io/" target="_blank" rel="noopener noreferrer">
+            <a href={DISCUSS_FORUM_URL} target="_blank" rel="noopener noreferrer">
               <div className="parentcard">
                 <div className="section-title">
                   <h2>Join the Conversation</h2>

--- a/site/src/components/Discuss-Callout/index.js
+++ b/site/src/components/Discuss-Callout/index.js
@@ -9,7 +9,7 @@ const DiscussCallout = () => {
       <div className="explain">
         <div className="cards">
           <div className="card">
-            <a href="https://discuss.layer5.io/" target="_blank" rel="noreferrer">
+            <a href="https://discuss.layer5.io/" target="_blank" rel="noopener noreferrer">
               <div className="parentcard">
                 <div className="section-title">
                   <h2>Join the Conversation</h2>

--- a/site/src/components/Footer/index.js
+++ b/site/src/components/Footer/index.js
@@ -105,7 +105,7 @@ const Footer = () => {
           </h3>
           <ul className="section-categories">
             <li>
-              <a className="category-link" href="http://discuss.meshery.io/">
+              <a className="category-link" href="https://discuss.layer5.io/">
                 Discussion Forum
               </a>
             </li>

--- a/site/src/components/Footer/index.js
+++ b/site/src/components/Footer/index.js
@@ -9,6 +9,7 @@ import LinkedinIcon from "../../assets/images/social-icons/linkedin.png";
 import BlueskyIcon from "../../assets/images/social-icons/bluesky.svg";
 import { ReactComponent as TwitterLogo } from "../../assets/images/social-icons/twitter.svg";
 import FooterWrapper from "./Footer.styles";
+import { DISCUSS_FORUM_URL } from "../../constants/links";
 
 const Footer = () => {
   return (
@@ -105,7 +106,7 @@ const Footer = () => {
           </h3>
           <ul className="section-categories">
             <li>
-              <a className="category-link" href="https://discuss.layer5.io/">
+              <a className="category-link" href={DISCUSS_FORUM_URL}>
                 Discussion Forum
               </a>
             </li>

--- a/site/src/components/Navigation/index.js
+++ b/site/src/components/Navigation/index.js
@@ -124,7 +124,7 @@ setScroll((window.scrollY || window.pageYOffset) > 50)
                 style={{ display: `${dropDown ? "block" : "none"}` }}
               >
                 <a
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   target="_blank"
                   className="drop-item"
                   href={`https://cloud.layer5.io/user/${userData.id}`}
@@ -132,7 +132,7 @@ setScroll((window.scrollY || window.pageYOffset) > 50)
                   <CloudIcon /> Cloud
                 </a>
                 <a
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   target="_blank"
                   className="drop-item"
                   href="https://playground.meshery.io"
@@ -148,7 +148,7 @@ setScroll((window.scrollY || window.pageYOffset) > 50)
                     // Refresh the current page
                     window.location.reload();
                   }}
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="drop-item"
                 >
                   <div className="drop-item-icon">

--- a/site/src/constants/links.js
+++ b/site/src/constants/links.js
@@ -1,0 +1,1 @@
+export const DISCUSS_FORUM_URL = "https://discuss.layer5.io/";

--- a/site/src/reusecore/Button/index.js
+++ b/site/src/reusecore/Button/index.js
@@ -27,7 +27,7 @@ const Button = ({
     <React.Fragment>
       {
         props.url ?
-          (<a href={props.url} target="_blank" rel="noreferrer">{initalButton}</a>)
+          (<a href={props.url} target="_blank" rel="noopener noreferrer">{initalButton}</a>)
           : initalButton
       }
     </React.Fragment>


### PR DESCRIPTION
Updated outdated discuss.meshery.io links to discuss.layer5.io.

Both:
- Footer → Discussion Forum
- "Join the Conversation" banner

now correctly redirect to the active forum.

Fixes #283