### PR TITLE
fix:update-community-discussion-link

### DIFF
--- a/site/src/constants/links.js
+++ b/site/src/constants/links.js
@@ -1,1 +1,1 @@
-export const DISCUSS_FORUM_URL = "https://meshery.io/community#discussion-forums";
+export const DISCUSS_FORUM_URL = "https://discuss.meshery.io";


### PR DESCRIPTION
**Notes for Reviewers**

This PR updates the community discussion forum link by replacing the [old URL](http://meshery.io/community#discussion-forums) with https://discuss.meshery.io.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
