### PR TITLE
fix(navigation): resolve overlapping of navbar behind buttons on scroll

### DIFF
--- a/site/src/components/Navigation/Navigation.styles.js
+++ b/site/src/components/Navigation/Navigation.styles.js
@@ -4,7 +4,7 @@ export const Header = styled.header`
   position: sticky;
   top: 0;
   background: #fff;
-  z-index: 1001;
+  z-index: 1001; /* Ensure header stays above overlapping page elements */
 
   .dropdown_btn {
     display: none;

--- a/site/src/components/Navigation/Navigation.styles.js
+++ b/site/src/components/Navigation/Navigation.styles.js
@@ -4,7 +4,7 @@ export const Header = styled.header`
   position: sticky;
   top: 0;
   background: #fff;
-  z-index: 2;
+  z-index: 1001;
 
   .dropdown_btn {
     display: none;


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #271 

It fixes the navbar overlapping by the buttons.

I am attaching the screen recording for the same:- 



https://github.com/user-attachments/assets/a6aba5c8-0155-4059-b484-b196f06da399



