### PR TITLE
fix: navbar stays above page content by using theme z-index constants

### DIFF
--- a/site/src/components/Navigation/Navigation.styles.js
+++ b/site/src/components/Navigation/Navigation.styles.js
@@ -4,7 +4,7 @@ export const Header = styled.header`
   position: sticky;
   top: 0;
   background: #fff;
-  z-index: 9999;
+  z-index: ${({ theme }) => theme.zIndex.navbar};
 
 
   .dropdown_btn {

--- a/site/src/components/Navigation/Navigation.styles.js
+++ b/site/src/components/Navigation/Navigation.styles.js
@@ -4,7 +4,8 @@ export const Header = styled.header`
   position: sticky;
   top: 0;
   background: #fff;
-  z-index: 2;
+  z-index: 9999;
+
 
   .dropdown_btn {
     display: none;

--- a/site/src/index.style.js
+++ b/site/src/index.style.js
@@ -155,6 +155,9 @@ export const lightTheme = {
   toggleBorder: '#FFF',
   background: '#363537',
   btn: '#FFF',
+  zIndex: {
+    navbar: 1000,
+  },
 }
 export const darkTheme = {
   body: 'rgb(18, 18, 18)',
@@ -162,4 +165,7 @@ export const darkTheme = {
   toggleBorder: '#6B8096',
   background: '#999',
   btn: '#1E2117',
+  zIndex: {
+    navbar: 1000,
+  },
 }


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #271.

Changes cherry-picked from #272 by @Nishika10 and rebased onto the latest `master`.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation bar layering so it consistently appears above other page content across light and dark themes.
* **Refactor**
  * Centralized navigation stacking behavior in the theme configuration for more consistent styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->