### PR TITLE
fix: add z-index fallback to navbar

### DIFF
--- a/site/src/components/Navigation/Navigation.styles.js
+++ b/site/src/components/Navigation/Navigation.styles.js
@@ -4,7 +4,10 @@ export const Header = styled.header`
   position: sticky;
   top: 0;
   background: #fff;
-  z-index: ${({ theme }) => theme?.zIndex?.navbar ?? 1000};
+  z-index: ${({ theme }) => {
+    const val = theme?.zIndex?.navbar;
+    return (Number.isFinite(val) && val > 999) ? val : 1000;
+  }};
 
 
   .dropdown_btn {

--- a/site/src/components/Navigation/Navigation.styles.js
+++ b/site/src/components/Navigation/Navigation.styles.js
@@ -4,7 +4,7 @@ export const Header = styled.header`
   position: sticky;
   top: 0;
   background: #fff;
-  z-index: ${({ theme }) => theme.zIndex.navbar};
+  z-index: ${({ theme }) => theme?.zIndex?.navbar ?? 1000};
 
 
   .dropdown_btn {


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #313 

## Summary

Fixes an issue where page-level buttons (z-index: 999) could render above the sticky navbar when the styled-components theme context failed to apply.

## Problem

`src/reusecore/Button/btn.style.js` applies `position: relative; z-index: 999` to every Button. The Header in `Navigation.styles.js` relied solely on `theme.zIndex.navbar` (= 1000) for its stacking order. If the theme context was absent or the value resolved to `undefined`, the header got no z-index, losing the stacking contest against z-index: 999 buttons.

## Changes

**`site/src/components/Navigation/Navigation.styles.js`**
- Added optional chaining and a `?? 1000` fallback to the header's z-index so it always resolves to a valid value regardless of theme availability:
  ```diff
  - z-index: ${({ theme }) => theme.zIndex.navbar};
  + z-index: ${({ theme }) => {
  + const val = theme?.zIndex?.navbar;
  + return (Number.isFinite(val) && val > 999) ? val : 1000;
  + }};

### Screen Recording

https://github.com/user-attachments/assets/66a83af1-69a1-4b4c-af0f-3d71389ff181



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header stability by applying a safe default stacking order when navigation settings are unavailable or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->